### PR TITLE
Fix: Allow environment authentication & Extra sleep for early time.After

### DIFF
--- a/gcs/collector.go
+++ b/gcs/collector.go
@@ -1,3 +1,18 @@
+// Copyright 2020 gcs-exporter Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//////////////////////////////////////////////////////////////////////////////
+
 package gcs
 
 import (

--- a/gcs/collector.go
+++ b/gcs/collector.go
@@ -2,7 +2,6 @@ package gcs
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"regexp"
 	"strings"
@@ -144,7 +143,7 @@ func (c *Collector) Update(ctx context.Context, yesterday time.Time) error {
 	c.metrics = metrics
 	c.mutex.Unlock()
 
-	fmt.Println("Update time:", time.Since(start))
+	log.Println("Total time to Update:", time.Since(start))
 	lastUpdateDuration.Set(time.Since(start).Seconds())
 	return err
 }

--- a/main.go
+++ b/main.go
@@ -1,3 +1,18 @@
+// Copyright 2020 gcs-exporter Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//////////////////////////////////////////////////////////////////////////////
+
 package main
 
 import (
@@ -82,8 +97,14 @@ func main() {
 		case <-mainCtx.Done():
 			return
 		case <-time.After(delay):
+			// NOTE: Update should only run once a day. time.After can return early
+			// under some conditions, which could result in running Update twice on
+			// the same day. So, continue to wait until current time is after 'next'.
+			for n := time.Now().UTC(); next.After(n); n = time.Now().UTC() {
+				log.Println("time.After fired early: sleeping", next.Sub(n))
+				time.Sleep(next.Sub(n))
+			}
 			// NOTE: ignore Update errors.
-			// NOTE: should only update once a day.
 			c.Update(mainCtx, priorDay)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/m-lab/go/prometheusx"
 	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/go/storagex"
+	"google.golang.org/api/option"
 
 	"cloud.google.com/go/storage"
 	"github.com/prometheus/client_golang/prometheus"
@@ -64,11 +65,15 @@ func nextUpdateTime(now time.Time, period, offset time.Duration) time.Time {
 	return aligned
 }
 
+var (
+	opts []option.ClientOption
+)
+
 func main() {
 	flag.Parse()
 	rtx.Must(flagx.ArgsFromEnv(flag.CommandLine), "Failed to parse args")
 
-	client, err := storage.NewClient(mainCtx)
+	client, err := storage.NewClient(mainCtx, opts...)
 	rtx.Must(err, "Failed to create client")
 
 	buckets := map[string]gcs.Walker{}

--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import (
 	"github.com/m-lab/go/prometheusx"
 	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/go/storagex"
-	"google.golang.org/api/option"
 
 	"cloud.google.com/go/storage"
 	"github.com/prometheus/client_golang/prometheus"
@@ -54,7 +53,7 @@ func main() {
 	flag.Parse()
 	rtx.Must(flagx.ArgsFromEnv(flag.CommandLine), "Failed to parse args")
 
-	client, err := storage.NewClient(mainCtx, option.WithoutAuthentication())
+	client, err := storage.NewClient(mainCtx)
 	rtx.Must(err, "Failed to create client")
 
 	buckets := map[string]gcs.Walker{}

--- a/main_test.go
+++ b/main_test.go
@@ -4,11 +4,13 @@ import (
 	"testing"
 
 	"github.com/m-lab/go/flagx"
+	"google.golang.org/api/option"
 )
 
 func Test_main(t *testing.T) {
 	// Run once with a cancelled main context to return immediately.
 	mainCancel()
+	opts = []option.ClientOption{option.WithoutAuthentication()}
 	sources = flagx.StringArray{"fake-gcs-bucket"}
 	main()
 }


### PR DESCRIPTION
This change addresses two issues discovered during early testing.

* Allow authentication for private GCS buckets.
* Because time.After can fire early, increment nextUpdate by 24hr every update.

As well, this change adds a license headers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcs-exporter/3)
<!-- Reviewable:end -->
