### PR TITLE
Use native prometheus metric types & per-bucket collection times

### DIFF
--- a/gcs/collector_test.go
+++ b/gcs/collector_test.go
@@ -8,9 +8,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/m-lab/go/prometheusx/promtest"
-	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/go/storagex"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 type fakeWalker struct {
@@ -37,43 +35,83 @@ func (f *fakeWalker) Dirs(ctx context.Context, prefix string) ([]string, error) 
 	return dirs, nil
 }
 
-func TestCollector_Registration(t *testing.T) {
+func TestUpdate(t *testing.T) {
 	tests := []struct {
 		name      string
 		yesterday time.Time
-		buckets   map[string]Walker
+		bucket    string
+		walker    Walker
 		wantErr   bool
 	}{
 		{
 			name:      "success",
 			yesterday: time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC),
-			buckets: map[string]Walker{
-				"fake-bucket-name": &fakeWalker{
-					dirs: map[string][]string{
-						// Root entry.
-						"":     []string{"ndt/"},
-						"ndt/": []string{"ndt/pcap/", "ndt/tcpinfo/"},
-					},
-					walk: map[string][]*storagex.Object{
-						"ndt/pcap/2019/01/01/": []*storagex.Object{
-							&storagex.Object{
-								ObjectHandle: &storage.ObjectHandle{},
-								ObjectAttrs: &storage.ObjectAttrs{
-									Size: 10,
-								},
+			bucket:    "fake-bucket-name",
+			walker: &fakeWalker{
+				dirs: map[string][]string{
+					// Root entry.
+					"":     []string{"ndt/"},
+					"ndt/": []string{"ndt/pcap/", "ndt/tcpinfo/"},
+				},
+				walk: map[string][]*storagex.Object{
+					"ndt/pcap/2019/01/01/": []*storagex.Object{
+						&storagex.Object{
+							ObjectHandle: &storage.ObjectHandle{},
+							ObjectAttrs: &storage.ObjectAttrs{
+								Size: 10,
 							},
 						},
-						"ndt/tcpinfo/2019/01/01/": []*storagex.Object{},
 					},
+					"ndt/tcpinfo/2019/01/01/": []*storagex.Object{},
 				},
 			},
+		},
+		{
+			name:      "error-dirs-first",
+			yesterday: time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC),
+			bucket:    "fake-bucket-name",
+			walker: &fakeWalker{
+				dirs: map[string][]string{
+					// Missing root record generates a fake error.
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:      "error-dirs-second",
+			yesterday: time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC),
+			bucket:    "fake-bucket-name",
+			walker: &fakeWalker{
+				dirs: map[string][]string{
+					"": []string{"ndt/"},
+					// Missing ndt record generates a fake error.
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:      "error-walk",
+			yesterday: time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC),
+			bucket:    "fake-bucket-name",
+			walker: &fakeWalker{
+				dirs: map[string][]string{
+					"":     []string{"ndt/"},
+					"ndt/": []string{"ndt/pcap/", "ndt/tcpinfo/"},
+				},
+				walk: map[string][]*storagex.Object{
+					// Missing record generates a fake error.
+				},
+			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewCollector(tt.buckets, tt.yesterday)
-			err := prometheus.Register(c)
-			rtx.Must(err, "Failed to register gcs collector")
+			ctx := context.Background()
+			err := Update(ctx, tt.bucket, tt.walker, tt.yesterday)
+			if tt.wantErr != (err != nil) {
+				t.Errorf("Failed to register gcs collector %s", err)
+			}
 
 			if !promtest.LintMetrics(t) {
 				t.Errorf("Metrics lint failed")

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"testing"
+	"time"
+
+	"github.com/m-lab/go/prometheusx"
 
 	"github.com/m-lab/go/flagx"
 	"google.golang.org/api/option"
@@ -12,5 +15,25 @@ func Test_main(t *testing.T) {
 	mainCancel()
 	opts = []option.ClientOption{option.WithoutAuthentication()}
 	sources = flagx.StringArray{"fake-gcs-bucket"}
+	exit := 0
+	logFatal = func(...interface{}) {
+		exit = 1
+	}
+
+	main()
+
+	if exit != 1 {
+		t.Fatal("Expected exit")
+	}
+}
+
+func Test_main_success(t *testing.T) {
+	// Run once with a cancelled main context to return immediately.
+	mainCancel()
+	opts = []option.ClientOption{option.WithoutAuthentication()}
+	*prometheusx.ListenAddress = ":0"
+	sources = flagx.StringArray{"fake-gcs-bucket"}
+	collectTimes = flagx.DurationArray{time.Second}
+
 	main()
 }


### PR DESCRIPTION
This change includes two updates:

* Use native prometheus counter metrics instead of a custom collector. This makes things simpler.
* Add per-bucket collection times.

After deploying the first version of gcs-exporter with a single collection time, I discovered that while data generated from the previous day is uploaded by 2:30 UTC, some experiments like tcpinfo, continue to write data to the previous day, meaning that archive uploads may occur indefinitely for a given date. This means that between the time that the pusher archive transfer is scheduled and the time that the bucked counts are scheduled new archives can be uploaded.

To prevent this mismatch, this change adds per-bucket collection times. With this the window of time for the archive transfer to begin and the accounting to complete, shrinks to seconds.